### PR TITLE
Fix error inheritance so that it's catchable by default.

### DIFF
--- a/lib/payroll_hero/api/errors.rb
+++ b/lib/payroll_hero/api/errors.rb
@@ -3,16 +3,17 @@ module PayrollHero
 
     module Errors
 
-      class GenericError < Exception
+      class GenericError < StandardError
       end
 
       class ServerReturnedError < GenericError
         def initialize(code, message)
           @code = code
+          @message = message
           super("#{code}: #{message}")
         end
 
-        attr_reader :code
+        attr_reader :code, :message
       end
 
       class BadRequest < ServerReturnedError

--- a/lib/payroll_hero/api/errors.rb
+++ b/lib/payroll_hero/api/errors.rb
@@ -9,11 +9,11 @@ module PayrollHero
       class ServerReturnedError < GenericError
         def initialize(code, message)
           @code = code
-          @message = message
+          @error_details = message
           super("#{code}: #{message}")
         end
 
-        attr_reader :code, :message
+        attr_reader :code, :error_details
       end
 
       class BadRequest < ServerReturnedError

--- a/lib/payroll_hero/api/version.rb
+++ b/lib/payroll_hero/api/version.rb
@@ -1,5 +1,5 @@
 module PayrollHero
   module Api
-    VERSION = "1.0.1"
+    VERSION = "1.0.2"
   end
 end


### PR DESCRIPTION
This will make GenericError inherit from StandardError rather than Exception.